### PR TITLE
Add geo-planner router to app

### DIFF
--- a/apps/web/components/Booking/steps/StepLocation.tsx
+++ b/apps/web/components/Booking/steps/StepLocation.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import dayjs from '@calcom/dayjs';
+import { trpc } from '@/app/_trpc/client';
+
+export default function StepLocation({ onNext, setBookingData, eventTypeId }: { onNext: () => void; setBookingData: any; eventTypeId: number }) {
+  const [ville, setVille] = useState('');
+  const [slots, setSlots] = useState<{ startTime: string; optimized?: boolean }[]>([]);
+
+  const fetchSlots = async () => {
+    const res = await trpc.geoPlanner.getSlots.query({ ville, eventTypeId, date: dayjs().format('YYYY-MM-DD') });
+    setSlots(res as any);
+  };
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-2">Où souhaitez-vous votre intervention&nbsp;?</h2>
+      <input className="border p-2 w-full" placeholder="Ville (ex : Montargis)" value={ville} onChange={e => setVille(e.target.value)} />
+      <button onClick={fetchSlots} className="bg-black text-white px-4 py-2 mt-3">Voir les créneaux</button>
+
+      {slots.map(s => (
+        <div key={s.startTime} className="mt-2">
+          {dayjs(s.startTime).format('HH:mm')} {s.optimized && '🟢 -10 €'}
+          <button className="ml-2 underline" onClick={() => { setBookingData((p: any) => ({ ...p, villeSouhaitee: ville, slot: s })); onNext(); }}>
+            Choisir
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/plugins/geo-planner/README.md
+++ b/packages/plugins/geo-planner/README.md
@@ -1,0 +1,8 @@
+# Geo Planner Plugin
+
+Provides travel-aware slot optimization.
+
+### TRPC Router
+`geoPlanner.getSlots({ eventTypeId, ville, date })`
+
+Returns available slots filtered with travel time buffers and marks optimized ones.

--- a/packages/plugins/geo-planner/index.ts
+++ b/packages/plugins/geo-planner/index.ts
@@ -1,0 +1,1 @@
+export * from './trpc-router';

--- a/packages/plugins/geo-planner/lib/computeOptimizedSlots.ts
+++ b/packages/plugins/geo-planner/lib/computeOptimizedSlots.ts
@@ -1,0 +1,42 @@
+import dayjs from '@calcom/dayjs';
+
+export interface Slot {
+  startTime: string;
+}
+
+export interface Booking {
+  endTime: Date;
+  metadata: any;
+}
+
+export function computeOptimizedSlots(
+  slots: Slot[],
+  bookings: Booking[],
+  travelMinutes: number,
+  ville: string,
+) {
+  const results: (Slot & { optimized?: boolean })[] = [];
+  for (const slot of slots) {
+    let hide = false;
+    let optimized = false;
+    const slotTime = dayjs(slot.startTime);
+    const slotLength = (slot as any).length ?? 50;
+    for (const booking of bookings) {
+      const bVille = booking.metadata?.ville;
+      if (!bVille || bVille === ville) continue;
+      const end = dayjs(booking.endTime);
+      const bufferEnd = end.add(slotLength + travelMinutes, 'minute');
+      if (slotTime.isBefore(bufferEnd)) {
+        hide = true;
+        break;
+      }
+      if (slotTime.isSame(bufferEnd)) {
+        optimized = true;
+      }
+    }
+    if (!hide) {
+      results.push({ ...slot, optimized });
+    }
+  }
+  return results;
+}

--- a/packages/plugins/geo-planner/package.json
+++ b/packages/plugins/geo-planner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@calcom/geo-planner",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.ts",
+  "files": ["**/*"],
+  "dependencies": {
+    "@calcom/trpc": "*",
+    "@calcom/prisma": "*",
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/plugins/geo-planner/trpc-router.ts
+++ b/packages/plugins/geo-planner/trpc-router.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { router, publicProcedure, createCallerFactory } from '@calcom/trpc/server/trpc';
+import { bookingsRouter } from '@calcom/trpc/server/routers/viewer/bookings/_router';
+import { slotsRouter } from '@calcom/trpc/server/routers/viewer/slots/_router';
+import { computeOptimizedSlots } from './lib/computeOptimizedSlots';
+
+const GetSlotsSchema = z.object({
+  eventTypeId: z.number().int(),
+  ville: z.string(),
+  date: z.string() // ISO date
+});
+
+export const geoPlannerRouter = router({
+  getSlots: publicProcedure.input(GetSlotsSchema).query(async ({ ctx, input }) => {
+    const createBookingsCaller = createCallerFactory(bookingsRouter);
+    const bookingsCaller = createBookingsCaller(ctx);
+    const { bookings } = await bookingsCaller.get({
+      limit: 50,
+      offset: 0,
+      filters: { status: 'upcoming' },
+    });
+
+    const createSlotsCaller = createCallerFactory(slotsRouter);
+    const slotsCaller = createSlotsCaller(ctx);
+    const { slots } = await slotsCaller.getSchedule({
+      startTime: `${input.date}T00:00:00Z`,
+      endTime: `${input.date}T23:59:59Z`,
+      eventTypeId: input.eventTypeId,
+    });
+
+    const optimized = computeOptimizedSlots(slots, bookings, 50, input.ville);
+    return optimized;
+  })
+});
+
+export type GeoPlannerRouter = typeof geoPlannerRouter;

--- a/packages/plugins/geo-planner/tsconfig.json
+++ b/packages/plugins/geo-planner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -2412,3 +2412,19 @@ model RolePermission {
   // TODO: come back to this with indexs.
   @@index([action])
 }
+
+model City {
+  id   Int    @id @default(autoincrement())
+  name String
+  lat  Float
+  lng  Float
+}
+
+model TravelTimeCache {
+  id      Int  @id @default(autoincrement())
+  cityA   Int
+  cityB   Int
+  minutes Int
+
+  @@unique([cityA, cityB])
+}

--- a/packages/trpc/server/routers/_app.ts
+++ b/packages/trpc/server/routers/_app.ts
@@ -3,6 +3,7 @@
  */
 import { router } from "../trpc";
 import { viewerRouter } from "./viewer/_router";
+import { geoPlannerRouter } from "@/plugins/geo-planner/trpc-router";
 
 /**
  * Create your application's root router
@@ -12,6 +13,7 @@ import { viewerRouter } from "./viewer/_router";
  */
 export const appRouter = router({
   viewer: viewerRouter,
+  geoPlanner: geoPlannerRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/trpc/server/routers/viewer/_router.tsx
+++ b/packages/trpc/server/routers/viewer/_router.tsx
@@ -38,6 +38,7 @@ import { slotsRouter } from "./slots/_router";
 import { ssoRouter } from "./sso/_router";
 import { viewerTeamsRouter } from "./teams/_router";
 import { travelSchedulesRouter } from "./travelSchedules/_router";
+import { geoPlannerRouter } from "@calcom/plugins/geo-planner/trpc-router";
 import { webhookRouter } from "./webhook/_router";
 import { workflowsRouter } from "./workflows/_router";
 
@@ -84,4 +85,5 @@ export const viewerRouter = router({
   credits: creditsRouter,
   ooo: oooRouter,
   travelSchedules: travelSchedulesRouter,
+  geoPlanner: geoPlannerRouter,
 });


### PR DESCRIPTION
## Summary
- connect geo-planner router at TRPC root
- compute slot buffer dynamically based on slot length
- remove placeholder BookingFlow component

## Testing
- `pnpm --filter @calcom/prisma exec prisma migrate dev --name geo-planner-init` *(fails: Command "prisma" not found)*
- `pnpm --filter @calcom/prisma exec prisma generate` *(fails: Command "prisma" not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d23664f083289238a43dccffb0e0